### PR TITLE
feat: DB connection 관리 할 수 있는 JpaConfig 추가

### DIFF
--- a/src/main/java/com/Buddymate/pickMate/config/JpaConfig.java
+++ b/src/main/java/com/Buddymate/pickMate/config/JpaConfig.java
@@ -1,0 +1,26 @@
+package com.Buddymate.pickMate.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+
+import javax.sql.DataSource;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(DataSource dataSource) {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(dataSource);
+        em.setPersistenceUnitName("pickMate");
+        return em;
+    }
+
+    @Bean
+    public JpaTransactionManager transactionManager(EntityManagerFactory emf) {
+        return new JpaTransactionManager(emf);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,10 @@
 spring.application.name=pickMate
 
+
+#HikariCP Connection Pool ??
+spring.datasource.hikari.maximum-pool-size=10
+spring.datasource.hikari.minimum-idle=2
+
 # MySQL
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=${DB_URL}


### PR DESCRIPTION
DB connection을 관리하는 EntityManager 설정이 없어 서버를 내렸다 올리면 DB connection이 증가함
1. JpaConfig 추가
- LocalContainerEntityManagerFactoryBean을 설정하여 EntityManagerFactory를 직접 관리
- JpaTransactionManager를 통해 트랜잭션이 끝나면 커넥션을 자동 반납하도록 설정
2. application.properties 수정
- HikariCP Pool 설정과 관련된 최대 풀 및 유후 상태 최소 풀 지정