### PR TITLE
fix : Spring Security 이전 JWT 토큰 인증 절차 추가

### DIFF
--- a/src/main/java/com/Buddymate/pickMate/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/Buddymate/pickMate/config/JwtAuthenticationFilter.java
@@ -1,0 +1,51 @@
+package com.Buddymate.pickMate.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Slf4j
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        String token = extractTokenFromRequest(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            String email = jwtTokenProvider.getEmailFromToken(token);
+
+            UserDetails userDetails = User.withUsername(email).password("").authorities("USER").build();
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else {
+            log.warn("JWT 검증 실패 또는 토큰 없음. 요청 URL: {}", request.getRequestURI());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (bearerToken != null && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/Buddymate/pickMate/config/SecurityConfig.java
+++ b/src/main/java/com/Buddymate/pickMate/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -32,7 +33,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/signup", "/api/auth/login").permitAll() // 로그인, 회원가입 인증 필요 X
                         .anyRequest().authenticated() // 나머지 요청은 인증 필요
-                );
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
 

--- a/src/main/java/com/Buddymate/pickMate/controller/UserController.java
+++ b/src/main/java/com/Buddymate/pickMate/controller/UserController.java
@@ -5,11 +5,13 @@ import com.Buddymate.pickMate.dto.UserResponseDto;
 import com.Buddymate.pickMate.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequestMapping("/api")
 @RequiredArgsConstructor
@@ -23,9 +25,15 @@ public class UserController {
         // 요청 헤더에서 Authorization 가져오기
         String token = extractTokenFromRequest(request);
 
+        if (token == null) {
+            log.warn("Authorization 헤더가 없거나 형식이 올바르지 않음");
+            return ResponseEntity.status(401).body("토큰이 필요합니다.");
+        }
+
         // 토큰 검증
-        if (token == null || !jwtTokenProvider.validateToken(token)) {
-            return ResponseEntity.status(401).build(); // 401 비인가
+        if (!jwtTokenProvider.validateToken(token)) {
+            log.warn("JWT 검증 실패: {}", token);
+            return ResponseEntity.status(401).body("유효하지 않은 토큰입니다.");
         }
 
         // 토큰에서 이메일 추출


### PR DESCRIPTION
Spring Security 필터 설정으로 JWT 토큰 인증 전 인터셉트.
인증된 사용자만 가능한 기능 시 JWT 토큰 검증 불가 및 403 Error 발생
-> BeforeFilter 적용 및 JWT 인증 필터 추가