### PR TITLE
feat : 한줄 소개 및 닉네임 변경 기능 추가

### DIFF
--- a/src/main/java/com/Buddymate/pickMate/controller/UserController.java
+++ b/src/main/java/com/Buddymate/pickMate/controller/UserController.java
@@ -4,6 +4,7 @@ import com.Buddymate.pickMate.config.JwtTokenProvider;
 import com.Buddymate.pickMate.dto.ProjectDto;
 import com.Buddymate.pickMate.dto.StudyDto;
 import com.Buddymate.pickMate.dto.UserResponseDto;
+import com.Buddymate.pickMate.dto.UserUpdateRequestDto;
 import com.Buddymate.pickMate.service.ProjectService;
 import com.Buddymate.pickMate.service.StudyService;
 import com.Buddymate.pickMate.service.UserService;
@@ -11,9 +12,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -52,6 +51,18 @@ public class UserController {
         UserResponseDto userInfo = userService.getUserByEmail(email);
 
         return ResponseEntity.ok(userInfo);
+    }
+
+    //한줄 소개 및 닉네임 수정
+    @PutMapping("/update")
+    public ResponseEntity<String> updateUser (HttpServletRequest request,
+                                              @RequestBody UserUpdateRequestDto dto) {
+        String email = jwtTokenProvider.getEmailFromToken(
+                extractTokenFromRequest(request));
+
+        userService.updateUser(email, dto);
+
+        return ResponseEntity.ok("사용자 정보가 업데이트 되었습니다.");
     }
 
     // 내가 등록한 프로젝트 리스트

--- a/src/main/java/com/Buddymate/pickMate/dto/UserUpdateRequestDto.java
+++ b/src/main/java/com/Buddymate/pickMate/dto/UserUpdateRequestDto.java
@@ -1,0 +1,11 @@
+package com.Buddymate.pickMate.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class UserUpdateRequestDto {
+    private String nickname;
+    private String introduction;
+
+}

--- a/src/main/java/com/Buddymate/pickMate/entity/User.java
+++ b/src/main/java/com/Buddymate/pickMate/entity/User.java
@@ -28,6 +28,9 @@ public class User implements UserDetails {
     @Column(nullable = false)
     private String password;
 
+    @Column(length = 1000)
+    private String introduction;
+
     @Temporal(TemporalType.TIMESTAMP)
     private Date createdAt = new Date();
 

--- a/src/main/java/com/Buddymate/pickMate/repository/UserRepository.java
+++ b/src/main/java/com/Buddymate/pickMate/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email); // 이메일로 유저 찾기
 
     Optional<User> findByNickname(String nickname); // 닉네임 중복 확인
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/Buddymate/pickMate/service/UserService.java
+++ b/src/main/java/com/Buddymate/pickMate/service/UserService.java
@@ -1,6 +1,7 @@
 package com.Buddymate.pickMate.service;
 
 import com.Buddymate.pickMate.dto.UserResponseDto;
+import com.Buddymate.pickMate.dto.UserUpdateRequestDto;
 import com.Buddymate.pickMate.entity.User;
 import com.Buddymate.pickMate.exception.CustomException;
 import com.Buddymate.pickMate.repository.UserRepository;
@@ -8,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Date;
 
 @Service
@@ -49,5 +52,22 @@ public class UserService {
         User user = userRepository.findByEmail(email).orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없음"));
 
         return new UserResponseDto(user);
+    }
+
+    // User 정보 수정
+    @Transactional
+    public void updateUser(String email, UserUpdateRequestDto dto) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        if (dto.getNickname() != null && !user.getNickname().equals(dto.getNickname())) {
+            if (userRepository.existsByNickname(dto.getNickname())) {
+                throw new IllegalArgumentException("이미 사용중인 닉네임입니다.");
+            }
+
+            user.setNickname(dto.getNickname());
+        }
+
+        user.setIntroduction(dto.getIntroduction());
     }
 }


### PR DESCRIPTION
한줄 소개 변경 기능 추가

- 닉네임 및 한줄 소개 변경 요청
- 닉네임이 같으면 무시하고 다르면 사용중인 닉네임인지 확인
- 한줄 소개 추가
- 요청 주소 : /api/my/update (PUT)
- 헤더 토큰 및 nickname, introduction 필요